### PR TITLE
Add UTF-8 support for item name in html

### DIFF
--- a/src/Util/functions.php
+++ b/src/Util/functions.php
@@ -58,6 +58,7 @@ function stripTagsAndContent($html)
     }
 
     $doc = new DOMDocument();
+    $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
     $doc->loadHTML("<div>{$html}</div>");
 
     $container = $doc->getElementsByTagName('div')->item(0);


### PR DESCRIPTION
## Description
Add UTF-8 support for item name in html
 
## Motivation and context
The selection of elements does not work in other languages, for example for Russian

## How has this been tested?

- Change the language of the site to Russian
- Run Scenario

```
Scenario: I can go to the Setting page
    Given I am logged in as an administrator
    And I am on the dashboard
    When I go to the menu "Настройки"
    Then I should be on "/wp-admin/options-general.php"
```
- I get `[W405] Menu item could not be found`

## Screenshots:
![image](https://user-images.githubusercontent.com/2115607/116546295-1f93c380-a8fa-11eb-8db3-51ecca20b8ad.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
